### PR TITLE
Add Stun-combo warning to FA [Brawler]

### DIFF
--- a/guides/3103.js
+++ b/guides/3103.js
@@ -6,6 +6,7 @@ module.exports = (dispatch, handlers, guide, lang) => {
 	let timer1 = null;
 	let print_target = true;
 	let in_bait = false;
+	let gettingserious = false; // ~70% attacks unlocked like Flip Kick Stun
 
 	function back_kick_event(skillid) {
 		if ([107, 310].includes(skillid)) { // Bait/Back Flip
@@ -46,14 +47,25 @@ module.exports = (dispatch, handlers, guide, lang) => {
 		}
 	}
 
+	function roundhouse() {
+		if (gettingserious) {
+			handlers.text({sub_type: "message", message: "Roundhouse Kick > Stun next", message_RU: "Удар с разворота > стан"});
+			return;
+		}
+		handlers.text({sub_type: "message", message: "Roundhouse Kick", message_RU: "Удар с разворота"});
+	}
+
 	return {
 		"nd-3103-1000": [
 			{ type: "stop_timers" },
 			{ type: "despawn_all" }
 		],
 
+		"h-3103-1000-99": [{ type: "func", func: () => gettingserious = false }], // reset after potential wipe
+		"h-3103-1000-70": [{ type: "func", func: () => gettingserious = true }],
+
 		//"s-3103-1000-101-0": [{ type: "text", class_position: "tank", sub_type: "message", message: "Punch", message_RU: "Серия ударов" }],
-		"s-3103-1000-113-0": [{ type: "text", class_position: "tank", sub_type: "message", message: "Roundhouse Kick", message_RU: "Удар с разворота" }],
+		"s-3103-1000-113-0": [{ type: "func", func: roundhouse, class_position: "tank" }],
 		"s-3103-1000-111-0": [{ type: "text", class_position: "tank", sub_type: "message", message: "Knockdown", message_RU: "Опрокид" }],
 		"s-3103-1000-120-0": [{ type: "text", class_position: "tank", sub_type: "message", message: "Knockdown", message_RU: "Опрокид" }],
 		//"s-3103-1000-102-0": [{ type: "text", class_position: "tank", sub_type: "message", message: "Combo", message_RU: "Комба" }], // 102 153/154 115/116


### PR DESCRIPTION
Undying Warload does the Flip-Kick stun (that needs to be iframed or else he will follow that with the Spin too, and everyone has a hard time) below 70% right after the Roundhousekick. 
If you didn't read a guide this may not be obvious to new players and the time you have to react on the `s-3103-1000-121-0` warning is almost impossible to dodge if not prepared for it.

This simply adds an earlier warning on the roundhouse kick that preceeds it.