### PR TITLE
update 3107

### DIFF
--- a/guides/3107.js
+++ b/guides/3107.js
@@ -2,16 +2,48 @@
 //
 // made by michengs / HSDN / ITunk
 
+const OPCODES = {
+	"S_DUNGEON_EVENT_GAGE": {
+		366226: 39917,
+		367078: 47028,
+		367081: 39359,
+		376012: 47078
+	}
+};
+
+function addOpcodeAndDefinition(mod, name, version = null, definition = null) {
+	if (OPCODES[name] !== undefined && OPCODES[name][mod.dispatch.protocolVersion] !== undefined) {
+		mod.dispatch.addOpcode(name, OPCODES[name][mod.dispatch.protocolVersion]);
+	}
+	if (version !== null && definition !== null) {
+		mod.dispatch.addDefinition(name, version, definition);
+	}
+}
+
 module.exports = (dispatch, handlers, guide, lang) => {
 	guide.type = SP;
 
-	let boss_ent = null;
+	addOpcodeAndDefinition(dispatch._mod, "S_DUNGEON_EVENT_GAGE", 2, [
+		["name", "refString"],
+		["message", "refString"],
+		["unk", "int32"],
+		["type", "int32"],
+		["value", "int32"],
+		["name", "string"],
+		["message", "string"]
+	]);
+
 	let boss_seventy = false;
 	let msg_a = "unk";
 	let msg_b = "unk";
 	let mech_reverse = false;
 	let mech_notice = false;
 	let s_attacks_notice = true;
+
+	const LEFT = 0;
+	const RIGHT = 1;
+	const UNKNOWN = -1;
+
 
 	const mech_messages = {
 		"out": { message: "Out", message_RU: "От него" },
@@ -163,46 +195,82 @@ module.exports = (dispatch, handlers, guide, lang) => {
 		}
 	}
 
-	function wave_attacks_event(side) {
-		// Left hand
-		if (side == "left") {
-			if (mech_reverse) {
-				// (0) Right safe
-				handlers.event([
-					{ type: "text", sub_type: "notification", message: "Right Safe", message_RU: "Справа сейф" },
-					{ type: "spawn", func: "marker", args: [false, 90, 300, 500, 3000, true, null] }
-				], boss_ent);
-			} else {
-				// (1) Left safe
-				handlers.event([
-					{ type: "text", sub_type: "notification", message: "Left Safe", message_RU: "Слева сейф" },
-					{ type: "spawn", func: "marker", args: [false, 270, 300, 500, 3000, true, null] }
-				], boss_ent);
-			}
+	let is_reverse = false;
+	let glowID
+	function wave_attacks_event() {
+		const duration = 4500;
+
+		const mech_message = {
+			0: [ // left safe
+				{ type: "spawn", func: "vector", args: [912, 360, 400, 180, 800, 0, duration] },
+				{ type: "spawn", func: "marker", args: [false, 300, 100, 0, duration, true, null] },
+				{ type: "spawn", func: "marker", args: [false, 230, 100, 0, duration, true, null] },
+			],
+			1: [ // right safe
+				{ type: "spawn", func: "vector", args: [912, 360, 400, 180, 800, 0, duration] },
+				{ type: "spawn", func: "marker", args: [false, 60, 100, 0, duration, true, null] },
+				{ type: "spawn", func: "marker", args: [false, 130, 100, 0, duration, true, null] },
+			]
+		};
+
+		let index = -1;
+		let side = glowID;
+		if (side === LEFT) {
+			index = is_reverse ? 1 : 0;
+		} else if (side === RIGHT) {
+			index = is_reverse ? 0 : 1;
 		}
 
-		// Right hand
-		if (side == "right") {
-			if (mech_reverse) {
-				// (0) Left safe
-				handlers.event([
-					{ type: "text", sub_type: "notification", message: "Left Safe", message_RU: "Слева сейф" },
-					{ type: "spawn", func: "marker", args: [false, 270, 300, 500, 3000, true, null] }
-				], boss_ent);
-			} else {
-				// (1) Right safe
-				handlers.event([
-					{ type: "text", sub_type: "notification", message: "Right Safe", message_RU: "Справа сейф" },
-					{ type: "spawn", func: "marker", args: [false, 90, 300, 500, 3000, true, null] }
-				], boss_ent);
+		if (index === -1) return;
+
+		handlers.event(mech_message[index]);
+
+		glowID = UNKNOWN;
+
+	}
+
+
+
+	let pizza_spawn_counter = 0;
+	let pizza_event_active = false;
+	let pizza_active_guide = false;
+	function laser_pizza_event() {
+		if (!pizza_active_guide) return;
+
+		if (pizza_spawn_counter >= 8) {
+			handlers.event([{
+				type: "spawn", func: "marker", args: [false, 0, (25 * 6), 0, 2000, false, null]
+			},])
+			return
+		}
+
+		pizza_spawn_counter++;
+		handlers.event([
+			// vertical
+			{ type: "spawn", func: "vector", args: [912, 0, 0, 0, (25 * 10), 0, 4500] },
+			{ type: "spawn", func: "vector", args: [912, 0, 0, 180, (25 * 10), 0, 4500] },
+			// horizontal
+			{ type: "spawn", func: "vector", args: [912, 0, 0, 90, (25 * 10), 0, 4500] },
+			{ type: "spawn", func: "vector", args: [912, 0, 0, 270, (25 * 10), 0, 4500] }
+		]);
+	}
+
+
+	dispatch.hook("S_DUNGEON_EVENT_GAGE", 2, event => {
+		if (event.name === "ScanProgress") {
+			if (event.value === 85) {
+				handlers.text({ sub_type: "message", message: "Drain Soon", message_RU: "Скоро дренаж" });
 			}
 		}
-	}
+	});
 
 	return {
 		"nd-3107-3000": [
 			{ type: "stop_timers" },
 			{ type: "despawn_all" }
+		],
+		"ns-3107-3003": [
+			{ type: "func", func: laser_pizza_event, check_func: () => pizza_event_active }
 		],
 		"h-3107-3000-99": [{ type: "func", func: () => boss_seventy = false }],
 		"h-3107-3000-70": [
@@ -237,85 +305,75 @@ module.exports = (dispatch, handlers, guide, lang) => {
 
 		// S-attacks right
 		"s-3107-3000-2114-0": [{ type: "func", func: s_attacks_event, args: ["right"] }],
-		"s-3107-3000-2114-1": [{ type: "func", func: s_attacks_event, args: ["right"] }],
-		"s-3107-3000-2114-2": [{ type: "func", func: s_attacks_event, args: ["right"] }],
-		"s-3107-3000-2114-3": [{ type: "func", func: s_attacks_event, args: ["right"] }],
-		"s-3107-3000-1331-0": [{ type: "func", func: s_attacks_event, args: ["right"] }],
-		"s-3107-3000-1331-1": [{ type: "func", func: s_attacks_event, args: ["right"] }],
-		"s-3107-3000-1331-2": [{ type: "func", func: s_attacks_event, args: ["right"] }],
-		"s-3107-3000-1331-3": [{ type: "func", func: s_attacks_event, args: ["right"] }],
-		"s-3107-3000-1112-1": [{ type: "func", func: s_attacks_event, args: ["right"] }],
-		"s-3107-3000-1107-0": [{ type: "func", func: s_attacks_event, args: ["right"] }],
-		"s-3107-3000-1107-2": [{ type: "func", func: s_attacks_event, args: ["right"] }],
+		"s-3107-3000-2114-1": "s-3107-3000-2114-0",
+		"s-3107-3000-2114-2": "s-3107-3000-2114-0",
+		"s-3107-3000-2114-3": "s-3107-3000-2114-0",
+		"s-3107-3000-1331-0": "s-3107-3000-2114-0",
+		"s-3107-3000-1331-1": "s-3107-3000-2114-0",
+		"s-3107-3000-1331-2": "s-3107-3000-2114-0",
+		"s-3107-3000-1331-3": "s-3107-3000-2114-0",
+		"s-3107-3000-1112-1": "s-3107-3000-2114-0",
+		"s-3107-3000-1107-0": "s-3107-3000-2114-0",
+		"s-3107-3000-1107-2": "s-3107-3000-2114-0",
 		//
-		"s-3107-3000-1119-0": [{ type: "func", func: s_attacks_event, args: ["right"] }],
-		"s-3107-3000-1119-1": [{ type: "func", func: s_attacks_event, args: ["right"] }],
-		"s-3107-3000-1119-2": [{ type: "func", func: s_attacks_event, args: ["right"] }],
-		"s-3107-3000-1119-3": [{ type: "func", func: s_attacks_event, args: ["right"] }],
-		"s-3107-3000-1323-0": [{ type: "func", func: s_attacks_event, args: ["right"] }],
-		"s-3107-3000-1323-1": [{ type: "func", func: s_attacks_event, args: ["right"] }],
-		"s-3107-3000-1323-2": [{ type: "func", func: s_attacks_event, args: ["right"] }],
-		"s-3107-3000-1323-3": [{ type: "func", func: s_attacks_event, args: ["right"] }],
-		"s-3107-3000-1127-1": [{ type: "func", func: s_attacks_event, args: ["right"] }],
-		"s-3107-3000-2118-0": [{ type: "func", func: s_attacks_event, args: ["right"] }],
-		"s-3107-3000-2118-2": [{ type: "func", func: s_attacks_event, args: ["right"] }],
+		"s-3107-3000-1119-0": "s-3107-3000-2114-0",
+		"s-3107-3000-1119-1": "s-3107-3000-2114-0",
+		"s-3107-3000-1119-2": "s-3107-3000-2114-0",
+		"s-3107-3000-1119-3": "s-3107-3000-2114-0",
+		"s-3107-3000-1323-0": "s-3107-3000-2114-0",
+		"s-3107-3000-1323-1": "s-3107-3000-2114-0",
+		"s-3107-3000-1323-2": "s-3107-3000-2114-0",
+		"s-3107-3000-1323-3": "s-3107-3000-2114-0",
+		"s-3107-3000-1127-1": "s-3107-3000-2114-0",
+		"s-3107-3000-2118-0": "s-3107-3000-2114-0",
+		"s-3107-3000-2118-2": "s-3107-3000-2114-0",
 
 		// S-attacks left
 		"s-3107-3000-1320-0": [{ type: "func", func: s_attacks_event, args: ["left"] }],
-		"s-3107-3000-1320-1": [{ type: "func", func: s_attacks_event, args: ["left"] }],
-		"s-3107-3000-1320-2": [{ type: "func", func: s_attacks_event, args: ["left"] }],
-		"s-3107-3000-1320-3": [{ type: "func", func: s_attacks_event, args: ["left"] }],
-		"s-3107-3000-1329-0": [{ type: "func", func: s_attacks_event, args: ["left"] }],
-		"s-3107-3000-1329-1": [{ type: "func", func: s_attacks_event, args: ["left"] }],
-		"s-3107-3000-1329-2": [{ type: "func", func: s_attacks_event, args: ["left"] }],
-		"s-3107-3000-1329-3": [{ type: "func", func: s_attacks_event, args: ["left"] }],
-		"s-3107-3000-1107-1": [{ type: "func", func: s_attacks_event, args: ["left"] }],
-		"s-3107-3000-1112-0": [{ type: "func", func: s_attacks_event, args: ["left"] }],
-		"s-3107-3000-1112-2": [{ type: "func", func: s_attacks_event, args: ["left"] }],
+		"s-3107-3000-1320-1": "s-3107-3000-1320-0",
+		"s-3107-3000-1320-2": "s-3107-3000-1320-0",
+		"s-3107-3000-1320-3": "s-3107-3000-1320-0",
+		"s-3107-3000-1329-0": "s-3107-3000-1320-0",
+		"s-3107-3000-1329-1": "s-3107-3000-1320-0",
+		"s-3107-3000-1329-2": "s-3107-3000-1320-0",
+		"s-3107-3000-1329-3": "s-3107-3000-1320-0",
+		"s-3107-3000-1107-1": "s-3107-3000-1320-0",
+		"s-3107-3000-1112-0": "s-3107-3000-1320-0",
+		"s-3107-3000-1112-2": "s-3107-3000-1320-0",
 		//
-		"s-3107-3000-1307-0": [{ type: "func", func: s_attacks_event, args: ["left"] }],
-		"s-3107-3000-1307-1": [{ type: "func", func: s_attacks_event, args: ["left"] }],
-		"s-3107-3000-1307-2": [{ type: "func", func: s_attacks_event, args: ["left"] }],
-		"s-3107-3000-1307-3": [{ type: "func", func: s_attacks_event, args: ["left"] }],
-		"s-3107-3000-2116-0": [{ type: "func", func: s_attacks_event, args: ["left"] }],
-		"s-3107-3000-2116-1": [{ type: "func", func: s_attacks_event, args: ["left"] }],
-		"s-3107-3000-2116-2": [{ type: "func", func: s_attacks_event, args: ["left"] }],
-		"s-3107-3000-2116-3": [{ type: "func", func: s_attacks_event, args: ["left"] }],
-		"s-3107-3000-2118-1": [{ type: "func", func: s_attacks_event, args: ["left"] }],
-		"s-3107-3000-1127-0": [{ type: "func", func: s_attacks_event, args: ["left"] }],
-		"s-3107-3000-1127-2": [{ type: "func", func: s_attacks_event, args: ["left"] }],
+		"s-3107-3000-1307-0": "s-3107-3000-1320-0",
+		"s-3107-3000-1307-1": "s-3107-3000-1320-0",
+		"s-3107-3000-1307-2": "s-3107-3000-1320-0",
+		"s-3107-3000-1307-3": "s-3107-3000-1320-0",
+		"s-3107-3000-2116-0": "s-3107-3000-1320-0",
+		"s-3107-3000-2116-1": "s-3107-3000-1320-0",
+		"s-3107-3000-2116-2": "s-3107-3000-1320-0",
+		"s-3107-3000-2116-3": "s-3107-3000-1320-0",
+		"s-3107-3000-2118-1": "s-3107-3000-1320-0",
+		"s-3107-3000-1127-0": "s-3107-3000-1320-0",
+		"s-3107-3000-1127-2": "s-3107-3000-1320-0",
 
 		// Basic attacks
 		"s-3107-3000-1110-0": [{ type: "text", sub_type: "message", message: "Front", message_RU: "Удар вперед" }],
-		"s-3107-3000-4000-0": [{ type: "text", sub_type: "message", message: "Front", message_RU: "Удар вперед" }],
+		"s-3107-3000-4000-0": "s-3107-3000-1110-0",
 		"s-3107-3000-1310-0": [{ type: "text", sub_type: "message", message: "Front | Back", message_RU: "Удар вперед | Удар назад" }],
-		"s-3107-3000-1321-0": [{ type: "text", sub_type: "message", message: "Front | Back", message_RU: "Удар вперед | Удар назад" }],
+		"s-3107-3000-1321-0": "s-3107-3000-1310-0",
 		"s-3107-3000-1115-0": [{ type: "text", sub_type: "message", message: "Back", message_RU: "Удар назад" }],
-		"s-3107-3000-1109-0": [{ type: "text", sub_type: "message", message: "Back", message_RU: "Удар назад" }],
+		"s-3107-3000-1109-0": "s-3107-3000-1115-0",
 
 		"s-3107-3000-1129-0": [
 			{ type: "text", sub_type: "message", message: "Combo | Back Wave", message_RU: "Комба | Конус назад" },
 			{ type: "spawn", func: "vector", args: [553, 180, 40, 120, 1200, 2000, 3000] },
 			{ type: "spawn", func: "vector", args: [553, 180, 40, 240, 1200, 2000, 3000] },
-			{ type: "func", func: ent => boss_ent = ent }
+			{ type: "func", func: () => is_reverse = mech_reverse }, // capture `mech_reverse` state as it might change by the time wave_attacks_event gets called
+			{ type: "func", delay: 1000, func: wave_attacks_event }
 		],
-		"s-3107-3000-1305-0": [
-			{ type: "text", sub_type: "message", message: "Combo | Back Wave", message_RU: "Комба | Конус назад" },
-			{ type: "spawn", func: "vector", args: [553, 180, 40, 120, 1200, 2000, 3000] },
-			{ type: "spawn", func: "vector", args: [553, 180, 40, 240, 1200, 2000, 3000] },
-			{ type: "func", func: ent => boss_ent = ent }
-		],
+		"s-3107-3000-1305-0": "s-3107-3000-1129-0",
 		"s-3107-3000-2102-0": [{ type: "text", class_position: "tank", sub_type: "message", message: "Dodge", message_RU: "Эвейд" }],
-		"s-3107-3000-2223-0": [{ type: "text", class_position: "tank", sub_type: "message", message: "Dodge", message_RU: "Эвейд" }],
+		"s-3107-3000-2223-0": "s-3107-3000-2102-0",
 		"s-3107-3000-2125-0": [{ type: "spawn", func: "circle", args: [false, 912, 0, 0, 10, 300, 0, 6000] }], // 310702 31070020 31070021 -> 305
-		"s-3107-3000-1313-0": [
-			{ type: "text", sub_type: "message", message: "Shield!", message_RU: "Щит!" },
-			{ type: "text", sub_type: "message", delay: 105000, message: "Shield in 10 seconds!", message_RU: "Через 10 сек. Щит!" }
-		],
-		"s-3107-3000-2115-0": [
-			{ type: "text", sub_type: "message", message: "Shield!", message_RU: "Щит!" },
-			{ type: "text", sub_type: "message", delay: 105000, message: "Shield in 10 seconds!", message_RU: "Через 10 сек. Щит!" }
-		],
+		"s-3107-3000-1313-0": [{ type: "text", sub_type: "message", message: "Shield!", message_RU: "Щит!" }],
+		"s-3107-3000-2115-0": "s-3107-3000-1313-0",
 		"s-3107-3001-1308-0": [
 			{ type: "text", sub_type: "message", message: "Bait!", message_RU: "Байт!" },
 			{ type: "spawn", func: "vector", args: [912, 0, 0, 0, 300, 0, 2000] },
@@ -323,20 +381,19 @@ module.exports = (dispatch, handlers, guide, lang) => {
 			{ type: "spawn", func: "vector", args: [912, 0, 0, 180, 300, 0, 2000] },
 			{ type: "spawn", func: "vector", args: [912, 0, 0, 270, 300, 0, 2000] }
 		],
-		"ab-3107-3000-310700020": [{ type: "text", sub_type: "notification", message: "Ready for Orbs", message_RU: "Готовность к бомбам" }],
+		"ab-3107-3000-310700020": [{ type: "text", sub_type: "notification", message: "Lasers Soon", message_RU: "Готовность к бомбам" }],
 
 		// Waves mech
-		"ab-3107-3000-310703401": [{ type: "func", func: wave_attacks_event, args: ["left"] }],
-		"ab-3107-3000-310703403": [{ type: "func", func: wave_attacks_event, args: ["left"] }],
-		"ab-3107-3000-310703405": [{ type: "func", func: wave_attacks_event, args: ["left"] }],
-		"ab-3107-3000-310703407": [{ type: "func", func: wave_attacks_event, args: ["left"] }],
-		"ab-3107-3000-310703408": [{ type: "func", func: wave_attacks_event, args: ["left"] }],
-		"ab-3107-3000-310703402": [{ type: "func", func: wave_attacks_event, args: ["right"] }],
-		"ab-3107-3000-310703404": [{ type: "func", func: wave_attacks_event, args: ["right"] }],
-		"ab-3107-3000-310703406": [{ type: "func", func: wave_attacks_event, args: ["right"] }],
-		"ab-3107-3000-310703409": [{ type: "func", func: wave_attacks_event, args: ["right"] }],
-		"ab-3107-3000-310703410": [{ type: "func", func: wave_attacks_event, args: ["right"] }],
-
+		"ab-3107-3000-310703401": [{ type: "func", func: () => glowID = LEFT }],
+		"ab-3107-3000-310703403": "ab-3107-3000-310703401",
+		"ab-3107-3000-310703405": "ab-3107-3000-310703401",
+		"ab-3107-3000-310703407": "ab-3107-3000-310703401",
+		"ab-3107-3000-310703408": "ab-3107-3000-310703401",
+		"ab-3107-3000-310703402": [{ type: "func", func: () => glowID = RIGHT }],
+		"ab-3107-3000-310703404": "ab-3107-3000-310703402",
+		"ab-3107-3000-310703406": "ab-3107-3000-310703402",
+		"ab-3107-3000-310703409": "ab-3107-3000-310703402",
+		"ab-3107-3000-310703410": "ab-3107-3000-310703402",
 		// Radar mech
 		"qb-3107-3000-31075430": [{ type: "text", sub_type: "message", message: "!!! Radar !!!", message_RU: "!!! Радар !!!" }],
 		"s-3107-3000-1118-0": [
@@ -350,6 +407,23 @@ module.exports = (dispatch, handlers, guide, lang) => {
 		"s-3107-3000-2107-0": [
 			{ type: "text", sub_type: "message", message: "IN", message_RU: "К НЕМУ" },
 			{ type: "spawn", func: "circle", args: [false, 553, 0, 0, 10, 300, 0, 3000] }
+		],
+		"s-3107-3000-1222-0": [
+			{ type: "func", func: () => pizza_event_active = true },
+			{ type: "text", sub_type: "message", message: "LASERS", message_RU: "ЛАЗЕРЫ" },
+			{ type: "func", delay: 3000, func: () => pizza_event_active = false },
+			{ type: "func", delay: 3000, func: () => pizza_spawn_counter = 0 },
+		],
+		"s-3107-3000-1306-0": "s-3107-3000-1222-0",
+		"s-3107-3000-1223-0": "s-3107-3000-1222-0",
+		"laser-helper": [ // activate with `!guide event t laser-helper`
+			{
+				type: "func", func: () => {
+					pizza_active_guide = !pizza_active_guide
+					let msg_state = pizza_active_guide ? "enabled" : "disabled";
+					dispatch._mod.command.message(`lasers markers have been ${msg_state}`);
+				}
+			},
 		]
 	};
 };

--- a/manifest.json
+++ b/manifest.json
@@ -16,7 +16,7 @@
         "guides/3103.js": "9a42e4b66954b95d99469001e1857f818fb9443cafe0dc2ed4dea34047c377cc",
         "guides/3104.js": "47aeff6d9ae5f7bbc2e1d0fc7e29fdbc58d7b5f51240843600d9900cb3b6b3e2",
         "guides/3106.js": "a5485af91dc71c2ff4ca3d83e3469043d787b1d121110885139ee3fa47e55072",
-        "guides/3107.js": "722173faacee66dafb32bdeb8e4bc3d31e16e157cdd0b066cb50cc17bea2eb1b",
+        "guides/3107.js": "1d9f9425a7eb472b26a1f5ba83c3ea0f1357ea921df9f02dbc14eda396f09133",
         "guides/3123.js": "d061aa0b3bf4115700c4763a73babaab0ea19a28c4661e07e92a5890f5498fc8",
         "guides/3126.js": "16717e0725fd0b9364ca5afa6bc077d9503b900d80abf88f72cd2db83d449cc1",
         "guides/3201.js": "36cbea3cc5c258d4c244659c4fe01eeecdb5dcef21cd3ab1bb81cf6a1d73ec6e",
@@ -68,7 +68,7 @@
         "index.js": "e96e5d5833e0c28967b3ac43f017af0e0c0a33ffa686f20c4398d86222eba491",
         "lang/dungeons.js": "4c4a16197bf9898e0a420c082c67457b007253db9a125cfe875e69c0fd0b16d9",
         "lang/strings.js": "33e95fa48d7a386620e561e696e52d7f72253bb1b2de749a99336110aaaade34",
-        "module.json": "3851220e85c6577bffbbcd21717d0173d0c96114a654d65d467c24003a9c9267",
+        "module.json": "a4f0fc7c90332023d83ebeea3a2b8f25943786de1839a6aa9c2333552c5c0dcd",
         "settings_migrator.js": "febf6c909b0bcfb5ce27c8336ddd6fb6fdf83d7f0549516e9cddc740f72b8ea6"
     }
 }

--- a/module.json
+++ b/module.json
@@ -15,5 +15,5 @@
         "tera-guide-core": "https://raw.githubusercontent.com/hsdn/tera-guide-core/master/module.json"
     },
     "disableAutoUpdate": false,
-    "version": "9/6/2024"
+    "version": "9/7/2024"
 }


### PR DESCRIPTION
- add warning call for drain mechanic at 85%
- update `wave_attacks_event` so that markers are spawned correctly if the boss turns
- add optional laser/orb markers. Could be useful for beginners on laser