### PR TITLE
update 3107

### DIFF
--- a/guides/3107.js
+++ b/guides/3107.js
@@ -67,7 +67,6 @@ module.exports = (dispatch, handlers, guide, lang) => {
 		hand_glow_id = UNKNOWN;
 		pizza_spawn_counter = 0;
 		pizza_event_active = false;
-		pizza_active_guide = false;
 	}
 
 	function code_announce_mech_event(code) {

--- a/manifest.json
+++ b/manifest.json
@@ -16,7 +16,7 @@
         "guides/3103.js": "9a42e4b66954b95d99469001e1857f818fb9443cafe0dc2ed4dea34047c377cc",
         "guides/3104.js": "47aeff6d9ae5f7bbc2e1d0fc7e29fdbc58d7b5f51240843600d9900cb3b6b3e2",
         "guides/3106.js": "a5485af91dc71c2ff4ca3d83e3469043d787b1d121110885139ee3fa47e55072",
-        "guides/3107.js": "989ff0a88d67dd2e3fab3d29af1cb0bd96de7a924d610f7d431fc45853413a8b",
+        "guides/3107.js": "dae1d54d414143a6d98d3a0c8ceb8d06b490fb3a8d0da625ba3713654941680f",
         "guides/3123.js": "d061aa0b3bf4115700c4763a73babaab0ea19a28c4661e07e92a5890f5498fc8",
         "guides/3126.js": "16717e0725fd0b9364ca5afa6bc077d9503b900d80abf88f72cd2db83d449cc1",
         "guides/3201.js": "36cbea3cc5c258d4c244659c4fe01eeecdb5dcef21cd3ab1bb81cf6a1d73ec6e",
@@ -68,7 +68,7 @@
         "index.js": "e96e5d5833e0c28967b3ac43f017af0e0c0a33ffa686f20c4398d86222eba491",
         "lang/dungeons.js": "4c4a16197bf9898e0a420c082c67457b007253db9a125cfe875e69c0fd0b16d9",
         "lang/strings.js": "33e95fa48d7a386620e561e696e52d7f72253bb1b2de749a99336110aaaade34",
-        "module.json": "a4f0fc7c90332023d83ebeea3a2b8f25943786de1839a6aa9c2333552c5c0dcd",
+        "module.json": "ba320e318c3186f9da48ef95323d88f865ae1f551d1a068083124f4809a5a045",
         "settings_migrator.js": "febf6c909b0bcfb5ce27c8336ddd6fb6fdf83d7f0549516e9cddc740f72b8ea6"
     }
 }

--- a/module.json
+++ b/module.json
@@ -15,5 +15,5 @@
         "tera-guide-core": "https://raw.githubusercontent.com/hsdn/tera-guide-core/master/module.json"
     },
     "disableAutoUpdate": false,
-    "version": "9/7/2024"
+    "version": "9/8/2024"
 }


### PR DESCRIPTION
don't reset `pizza_active_guide` state since we don't want to type the command to activate laser-helper after every wipe